### PR TITLE
Support self-hosted plausible, and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This Hugo theme is a dead simple integration between [plausible.io](https://www.
 
 ```toml
 [params.plausible]
-   enable      = true
-   subdomain   = false
-   analytics   = "put-here-your-plausible-analytics-code"
+   enable      = true  # Whether to enable plausible tracking
+   custom_domain   = "stats.example.com"  # Whether to serve the script from a custom domain (https://docs.plausible.io/custom-domain)
+   domain   = "example.com"
 ```
 
 ## Custom goals

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This Hugo theme is a dead simple integration between [plausible.io](https://www.
 ```toml
 [params.plausible]
    enable      = true  # Whether to enable plausible tracking
-   domain   = "example.com"
-   custom_domain   = "stats.example.com"  # Whether to serve the script from a custom domain (https://docs.plausible.io/custom-domain) (Optional)
-   plausible_domain = "myplausible.example.com"  # Self-hosted plausible domain (Optional. "plausible.io" is used if unset)
+   domain   = "example.com"  # This is the plausible "domain" name/id in your dashboard
+   custom_js_domain   = "stats.example.com"  # Whether to serve the script from a custom domain (https://docs.plausible.io/custom-domain) (Optional)
+   selfhosted_domain = "myplausible.example.com"  # Self-hosted plausible domain (Optional. "plausible.io" is used if unset)
 ```
 
 ## Custom goals

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This Hugo theme is a dead simple integration between [plausible.io](https://www.
 ```toml
 [params.plausible]
    enable      = true  # Whether to enable plausible tracking
-   custom_domain   = "stats.example.com"  # Whether to serve the script from a custom domain (https://docs.plausible.io/custom-domain)
    domain   = "example.com"
+   custom_domain   = "stats.example.com"  # Whether to serve the script from a custom domain (https://docs.plausible.io/custom-domain) (Optional)
    plausible_domain = "myplausible.example.com"  # Self-hosted plausible domain (Optional. "plausible.io" is used if unset)
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This Hugo theme is a dead simple integration between [plausible.io](https://www.
    enable      = true  # Whether to enable plausible tracking
    custom_domain   = "stats.example.com"  # Whether to serve the script from a custom domain (https://docs.plausible.io/custom-domain)
    domain   = "example.com"
+   plausible_domain = "myplausible.example.com"  # Self-hosted plausible domain (Optional. "plausible.io" is used if unset)
 ```
 
 ## Custom goals

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
 [params.plausible]
    enable = true
-   custom_domain = "stats.example.com"
-   domain = "example.com"
+   custom_js_domain = "stats.example.com"
+   selfhosted_domain = "example.com"

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
 [params.plausible]
-   enable      = true
-   subdomain   = false
-   analytics   = "your-plausible-code"
+   enable = true
+   custom_domain = "stats.example.com"
+   domain = "example.com"

--- a/layouts/partials/plausible_head.html
+++ b/layouts/partials/plausible_head.html
@@ -3,12 +3,12 @@
     {{- if site.Params.plausible.enable }}
         <!-- To avoid stats bloat when in dev/server mode -->
         {{- if not site.IsServer -}}
-            {{- if site.Params.plausible.custom_domain }}
+            {{- if site.Params.plausible.custom_js_domain }}
                 <!-- Script via custom domain -->
-                <script async defer data-domain="{{ site.Params.plausible.domain }}" src="https://{{ site.Params.plausible.custom_domain }}/js/index.js"></script>
+                <script async defer data-domain="{{ site.Params.plausible.domain }}" src="https://{{ site.Params.plausible.custom_js_domain }}/js/index.js"></script>
             {{- else }}
                 <!-- Script direct -->
-                <script async defer data-domain="{{ site.Params.plausible.domain }}" src="https://{{ default "plausible.io" site.Params.plausible.plausible_domain }}/js/plausible.js"></script>
+                <script async defer data-domain="{{ site.Params.plausible.domain }}" src="https://{{ default "plausible.io" site.Params.plausible.selfhosted_domain }}/js/plausible.js"></script>
             {{- end }}
         {{- end }}
 

--- a/layouts/partials/plausible_head.html
+++ b/layouts/partials/plausible_head.html
@@ -8,7 +8,7 @@
                 <script async defer data-domain="{{ site.Params.plausible.domain }}" src="https://{{ site.Params.plausible.custom_domain }}/js/index.js"></script>
             {{- else }}
                 <!-- Script direct -->
-                <script async defer data-domain="{{ site.Params.plausible.domain }}" src="https://plausible.io/js/plausible.js"></script>
+                <script async defer data-domain="{{ site.Params.plausible.domain }}" src="https://{{ default "plausible.io" site.Params.plausible.plausible_domain }}/js/plausible.js"></script>
             {{- end }}
         {{- end }}
 

--- a/layouts/partials/plausible_head.html
+++ b/layouts/partials/plausible_head.html
@@ -3,12 +3,12 @@
     {{- if site.Params.plausible.enable }}
         <!-- To avoid stats bloat when in dev/server mode -->
         {{- if not site.IsServer -}}
-            {{- if site.Params.plausible.subdomain }}
-                <!-- Script via SUBDOMAIN custom.plausible.io -->
-                <script async defer data-domain="{{ site.Params.plausible.analytics }}" src="https://stats.{{ site.Params.plausible.analytics }}/js/index.js"></script>
+            {{- if site.Params.plausible.custom_domain }}
+                <!-- Script via custom domain -->
+                <script async defer data-domain="{{ site.Params.plausible.domain }}" src="https://{{ site.Params.plausible.custom_domain }}/js/index.js"></script>
             {{- else }}
-                <!-- Script DIRECT via plausible.io -->
-                <script async defer data-domain="{{ site.Params.plausible.analytics }}" src="https://plausible.io/js/plausible.js"></script>
+                <!-- Script direct -->
+                <script async defer data-domain="{{ site.Params.plausible.domain }}" src="https://plausible.io/js/plausible.js"></script>
             {{- end }}
         {{- end }}
 

--- a/layouts/partials/plausible_head.html
+++ b/layouts/partials/plausible_head.html
@@ -1,21 +1,23 @@
 {{- if site.Params.plausible }}
-<!-- Active plausible on/off -->
-{{- if site.Params.plausible.enable }}
-    <!-- To avoid stats bloat when in dev/server mode -->
-    {{- if not site.IsServer -}}
-    {{- if site.Params.plausible.subdomain }}
-        <!-- Script via SUBDOMAIN custom.plausible.io -->
-        <script async defer data-domain="{{ site.Params.plausible.analytics }}" src="https://stats.{{ site.Params.plausible.analytics }}/js/index.js"></script>
-    {{- else }}
-        <!-- Script DIRECT via plausible.io -->
-        <script async defer data-domain="{{ site.Params.plausible.analytics }}" src="https://plausible.io/js/plausible.js"></script>
-    {{- end}}
+    <!-- Active plausible on/off -->
+    {{- if site.Params.plausible.enable }}
+        <!-- To avoid stats bloat when in dev/server mode -->
+        {{- if not site.IsServer -}}
+            {{- if site.Params.plausible.subdomain }}
+                <!-- Script via SUBDOMAIN custom.plausible.io -->
+                <script async defer data-domain="{{ site.Params.plausible.analytics }}" src="https://stats.{{ site.Params.plausible.analytics }}/js/index.js"></script>
+            {{- else }}
+                <!-- Script DIRECT via plausible.io -->
+                <script async defer data-domain="{{ site.Params.plausible.analytics }}" src="https://plausible.io/js/plausible.js"></script>
+            {{- end }}
+        {{- end }}
+
+        <!-- For custom goals/events -->
+        <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+
+        <!-- Create a unique script for all the onclick -->
+        <script>
+            {{ partial "plausible_js.html" . | safeJS }}
+        </script>
     {{- end }}
-    <!-- For custom goals/events -->
-    <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
-    <!-- Create a unique script for all the onclick -->
-    <script>
-        {{ partial "plausible_js.html" . | safeJS }}
-    </script>
-{{- end }}
 {{- end }}


### PR DESCRIPTION
Each commit is nice and atomic.

This PR started off as just adding support for a custom plausible instance, but turned into something a little more.

- Correctly indent lines to make reading easier
- Rename config keys (**breaking change**) so it's more obvious what they're doing, and there's less overlap
- Add a `plausible_domain` to define where plausible itself lives