### PR TITLE
Fix _redirect status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ If you are hosting on Netlify, we have done the [main setup](https://plausible.i
 
 ```txt
 /misc/js/script.js https://plausible.io/js/plausible.js 200
-/misc/api/event https://plausible.io/api/event 202
+/misc/api/event https://plausible.io/api/event 200
 ```
 
 If you want outbound-links, use this line instead:


### PR DESCRIPTION
Was recently following this guide to proxy Plausible via Hugo and noticed that the status code for the `_redirect` section was giving me errors in Netlify.

Netlify has a redirects playground where I tested these rules and can see the error:

https://play.netlify.com/redirects

![image](https://user-images.githubusercontent.com/19419349/167291058-24067744-d293-4790-99cc-e1579c3e6b91.png)

By changing to `200` for the `event`, we can see it passes.

![image](https://user-images.githubusercontent.com/19419349/167291083-d7e4276d-63f8-4367-b0f3-831dc1ccc8c0.png)

Also, the Plausible docs [Proxying Plausible through Netlify - Step 1: Add URL rewrite rules](https://plausible.io/docs/proxy/guides/netlify#step-1-add-url-rewrite-rules) lists this rule to use `200` for the `event` as well.

![image](https://user-images.githubusercontent.com/19419349/167291112-74ec46e3-2115-4890-8e74-4d3b6567ad18.png)
