### PR TITLE
Manage .Sites.First deprecation

### DIFF
--- a/layouts/partials/plausible_check.html
+++ b/layouts/partials/plausible_check.html
@@ -16,7 +16,7 @@
 
 <!-- Write console hint about leaving a star for this module on GitHub -->
 {{- if or ( site.Params.plausible.gitstar ) (not (isset site.Params.plausible "gitstar")) }}
-{{- if eq site.Language site.Sites.First.Language }}
+{{- if eq site.Language site.Sites.Default.Language }}
    <!-- Write information IN CONSOLE about the plugin -->
    {{- $warn := i18n "plausible_gitstar" }}
    {{- warnf $warn }}


### PR DESCRIPTION
Usage of .Sites.First was deprecated in Hugo v0.127.0 and will be removed in Hugo 0.140.0. Use .Sites.Default instead.